### PR TITLE
feat: add asUser and asSystem API

### DIFF
--- a/force-app/commons/database/DatabaseService.cls
+++ b/force-app/commons/database/DatabaseService.cls
@@ -68,6 +68,23 @@ public class DatabaseService {
         return this;
     }
 
+    /**
+     * Executes DMLs and Quries in With Sharing context and user access level
+     */
+    public DatabaseService asUser() {
+        this.dmlIssuer = new WithSharingDMLIssuer();
+        this.setAccessLevel(AccessLevel.USER_MODE);
+        return this;
+    }
+
+    /**
+     * Executes DMLs and Quries in Without Sharing context and system access level
+     */
+    public DatabaseService asSystem() {
+        this.dmlIssuer = new WithoutSharingDMLIssuer();
+        this.setAccessLevel(AccessLevel.SYSTEM_MODE);
+        return this;
+    }
 
     /**
      * SYSTEM_MODE - Execution mode in which the the object and field-level permissions of the current user are ignored,

--- a/force-app/commons/database/DatabaseServiceTest.cls
+++ b/force-app/commons/database/DatabaseServiceTest.cls
@@ -37,6 +37,8 @@ private class DatabaseServiceTest {
         coverDatabaseServiceMethods(new DatabaseService(), acc);
         coverDatabaseServiceMethods(new DatabaseService().withSharing(), acc);
         coverDatabaseServiceMethods(new DatabaseService().withoutSharing(), acc);
+        coverDatabaseServiceMethods(new DatabaseService().asSystem(), acc);
+        coverDatabaseServiceMethods(new DatabaseService().asUser(), acc);
     }
 
     private static void coverDatabaseServiceMethods(DatabaseService databaseService, Account acc) {
@@ -73,6 +75,24 @@ private class DatabaseServiceTest {
 
 
         databaseService.withoutSharing();
+        actual = databaseService.query('SELECT ID FROM User WHERE ID IN :users', new Map<String, Object>{'users' => expected});
+        queryLocator = databaseService.getQueryLocator('SELECT ID FROM User WHERE ID IN :users', new Map<String, Object>{'users' => expected});
+
+        System.assertEquals(
+            new Map<Id, User>(expected).keySet(),
+            new Map<Id, User>(actual).keySet()
+        );
+
+        databaseService.asUser();
+        actual = databaseService.query('SELECT ID FROM User WHERE ID IN :users', new Map<String, Object>{'users' => expected});
+        queryLocator = databaseService.getQueryLocator('SELECT ID FROM User WHERE ID IN :users', new Map<String, Object>{'users' => expected});
+
+        System.assertEquals(
+            new Map<Id, User>(expected).keySet(),
+            new Map<Id, User>(actual).keySet()
+        );
+
+        databaseService.asSystem();
         actual = databaseService.query('SELECT ID FROM User WHERE ID IN :users', new Map<String, Object>{'users' => expected});
         queryLocator = databaseService.getQueryLocator('SELECT ID FROM User WHERE ID IN :users', new Map<String, Object>{'users' => expected});
 


### PR DESCRIPTION
# Motivation

With the new access level system and user mode it is know simpler and clearer to provide a way to check for FLS, Object permissions and sharing, or to simply ignore them.

The goal of this PR is to add two simple API to setup the DatabaseService to either run as user (FLS, Object Permission and sharing enforced) or as system (without sharing, FLS and Object Permission).
This way Developer just have one line of code to use the DatabaseService they need instead of Two currently (adding the setAccessLevel).

Currently the API allow developer to set 4 kinds of mechanism : 
- without sharing with system access level => System Mode
- with sharing with user access level => User mode
- with sharing with system access level => Bypass FLS and Object Permission on data you can reach. It can raises multiple question : 
	- Is it a configuration miss and should be covered by permission set ?
	- Is it system mode and should be run in without sharing ?
	- Could it be covered using user mode [withPermissionSetId](https://developer.salesforce.com/docs/atlas.en-us.apexref.meta/apexref/apex_class_System_AccessLevel.htm#apex_System_AccessLevel_withPermissionSetId) ? 
- without sharing with user access level => Access object you should not reach and manipulate them with your current FLS and Object Permission. 
	- Is it system mode use case ?
	- Is it an OWD miss in the configuration ?

The aim of this PR is to open the discussion about the API proposed to developer currently (without this PR).
The end goal is to simplify the developer experience.

# Explain your changes

Expose 2 new methods in the `DatabaseService` class: 
- `asUser`: `with sharing` sharing mode via `withSharingDMLIssuer` and `AccessLevel.USER_MODE` access level
- `asSystem`: `without sharing` sharing mode via `withoutSharingDMLIssuer` and `AccessLevel.SYSTEM_MODE` access level
