### PR TITLE
Add rate limit syntax sugar

### DIFF
--- a/force-app/commons/callout/CalloutConditions.cls
+++ b/force-app/commons/callout/CalloutConditions.cls
@@ -48,6 +48,13 @@ public with sharing class CalloutConditions extends Conditions {
     }
 
     /**
+     * Executes when webservice returned 429 Rate Limit
+     */
+    public Condition onRateLimit() {
+      return onStatusCode(429);
+    }
+
+    /**
      * Executes when webservice timed out
      */
     public Condition onTimeout() {


### PR DESCRIPTION
Could be argued that this needs a more robust implementation that looks at response headers.

Usage

```apex
Callout c = new Callout();
c.onAfterCallout()
  .add(match.onRateLimit(), action.retry(1))
```